### PR TITLE
Update Dockerfile for glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ LABEL maintainer="Ralyon: ralyon76+gh@gmail.com"
 
 RUN apt-get update && apt-get upgrade -y && \
 	apt-get install -y tmux && \
+	sed -i 's/bullseye/bookworm/g' /etc/apt/sources.list && \
+	apt-get update && apt-get install -y libc6 libstdc++6 && \
+	sed -i 's/bookworm/bullseye/g' /etc/apt/sources.list && \
 	rm -rf /var/lib/apt/lists/*
 
 ENV INSTALLDIR="/home/steam/stationeers"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ docker-compose up
 | `SERVER_PLAYERS` | `10` | Set the max number of players that can connect |
 | `SERVER_AUTO_SAVE` | `true` | Set to false if you do not want the server automatically saving |
 | `SERVER_SAVE_INTERVAL` | `300` | Automatic save interval in seconds |
-| `SERVER_DIFFICULTY` | `Easy` | Set difficulty level to Easy, Normal or Stationeer |
+| `SERVER_DIFFICULTY` | `Normal` | Set difficulty level to Easy, Normal or Stationeer |
 | `GAME_PORT` | `27016` | Used for both incoming client connections (Make sure this is forwarded and not firewalled) |
 | `SERVER_PASSWORD` | | Server password |
 | `SERVER_PUBLIC` | `false` | Set to true if you want your server advertised on the public list |


### PR DESCRIPTION
Adding run commands to install glibc from testing to support new version of stationeers that requires a version not in the stable branch of Debian